### PR TITLE
fix: fedimint-ts entrypoint

### DIFF
--- a/wrappers/fedimint-ts/package-lock.json
+++ b/wrappers/fedimint-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fedimint-ts",
-  "version": "0.2.23",
+  "version": "0.2.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fedimint-ts",
-      "version": "0.2.23",
+      "version": "0.2.25",
       "license": "MIT",
       "dependencies": {
         "crypto": "^1.0.1",

--- a/wrappers/fedimint-ts/package.json
+++ b/wrappers/fedimint-ts/package.json
@@ -2,8 +2,9 @@
   "name": "fedimint-ts",
   "author": "The Fedimint Developers",
   "description": "A TypeScript Wrapper for the Fedimint HTTP Client",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "license": "MIT",
+  "main": "dist/index.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
@Kodylow , I missed to declare an entry point for `fedimint-ts`.
Also, you'de need to `npm run build` before `npm publish` in order for the dist assets to be published.
These two mishaps make [`v0.2.24`](https://www.npmjs.com/package/fedimint-ts/v/0.2.24) unusable

We should eventually automate the publish pipeline for these assets.

Related to https://github.com/fedimint/ui/issues/354