### PR TITLE
fix: multimint version conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
  "lazy_static",
  "lightning-invoice",
  "lnurl-rs",
- "multimint 0.3.5",
+ "multimint 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.12.4",
  "serde",
  "serde_json",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-clientd"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-utility",
@@ -1075,7 +1075,7 @@ dependencies = [
  "lazy_static",
  "lightning-invoice",
  "lnurl-rs",
- "multimint 0.3.5",
+ "multimint 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.12.4",
  "serde",
  "serde_json",
@@ -2440,9 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "multimint"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0c503e9c657a41398fe1ff762214fd57488b365345deea24a92c8ade01e1f2"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -2463,6 +2461,8 @@ dependencies = [
 [[package]]
 name = "multimint"
 version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9989e73f689a15421660f72b902165b5e4579d1cb0d2f208108ea374b0bbf2d7"
 dependencies = [
  "anyhow",
  "fedimint-client",

--- a/clientd-stateless/Cargo.toml
+++ b/clientd-stateless/Cargo.toml
@@ -37,7 +37,7 @@ time = { version = "0.3.25", features = ["formatting"] }
 chrono = "0.4.31"
 futures-util = "0.3.30"
 clap = { version = "3", features = ["derive", "env"] }
-multimint = { version = "0.3.5" }
+multimint = { version = "0.3.6" }
 # multimint = { path = "../multimint" }
 axum-otel-metrics = "0.8.0"
 base64 = "0.22.0"


### PR DESCRIPTION
```shell
$ cargo build
    Updating crates.io index
error: failed to select a version for `multimint`.
    ... required by package `clientd-stateless v0.3.5 (/home/henrique/Projects/fedimint-clientd/clientd-stateless)`
versions that meet the requirements `^0.3.5` (locked to 0.3.5) are: 0.3.5

all possible versions conflict with previously selected packages.

  previously selected package `multimint v0.3.6`
    ... which satisfies dependency `multimint = "^0.3.6"` of package `fedimint-clientd v0.3.6 (/home/henrique/Projects/fedimint-clientd/fedimint-clientd)`

failed to select a version for `multimint` which could resolve this conflict
```