### PR TITLE
fix: add Clone and PartialEq to InfoResponse (multimint)

### DIFF
--- a/multimint/src/types.rs
+++ b/multimint/src/types.rs
@@ -5,7 +5,7 @@ use fedimint_core::{Amount, TieredSummary};
 use serde::Serialize;
 
 /// InfoResponse for getting the Federation Config info
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct InfoResponse {
     pub federation_id: FederationId,

--- a/multimint/src/types.rs
+++ b/multimint/src/types.rs
@@ -5,7 +5,7 @@ use fedimint_core::{Amount, TieredSummary};
 use serde::Serialize;
 
 /// InfoResponse for getting the Federation Config info
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct InfoResponse {
     pub federation_id: FederationId,


### PR DESCRIPTION
Been having some trouble using the Multimint library since I can't clone InfoResponse or compare it with PartialEq.

Would be nice to have in the next version.